### PR TITLE
feat: migrate PostgreSQL and Redis configurations to StatefulSets

### DIFF
--- a/k8s/base/postgres/postgres.yaml
+++ b/k8s/base/postgres/postgres.yaml
@@ -1,14 +1,4 @@
 apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: postgres-pvc
-spec:
-  accessModes: ["ReadWriteOnce"]
-  resources:
-    requests:
-      storage: 10Gi
----
-apiVersion: v1
 kind: Service
 metadata:
   name: postgres
@@ -21,10 +11,11 @@ spec:
       targetPort: 5432
 ---
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: postgres
 spec:
+  serviceName: postgres
   replicas: 1
   selector:
     matchLabels:
@@ -50,9 +41,13 @@ spec:
                   name: sba-secrets
                   key: POSTGRES_PASSWORD
           volumeMounts:
-            - name: data
+            - name: postgres-data
               mountPath: /var/lib/postgresql/data
-      volumes:
-        - name: data
-          persistentVolumeClaim:
-            claimName: postgres-pvc
+  volumeClaimTemplates:
+    - metadata:
+        name: postgres-data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: 30Gi

--- a/k8s/base/redis/redis.yaml
+++ b/k8s/base/redis/redis.yaml
@@ -11,10 +11,11 @@ spec:
       targetPort: 6379
 ---
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: redis
 spec:
+  serviceName: redis
   replicas: 1
   selector:
     matchLabels:
@@ -29,3 +30,15 @@ spec:
           image: redis:7
           ports:
             - containerPort: 6379
+          command: ["redis-server", "--appendonly", "yes"]
+          volumeMounts:
+            - name: redis-data
+              mountPath: /data
+  volumeClaimTemplates:
+    - metadata:
+        name: redis-data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: 2Gi


### PR DESCRIPTION
This pull request updates the Kubernetes manifests for both Postgres and Redis to improve data persistence and reliability by migrating from Deployments to StatefulSets .